### PR TITLE
Enforce log level

### DIFF
--- a/src/lib/webtop/Log.php
+++ b/src/lib/webtop/Log.php
@@ -28,7 +28,7 @@ class Log {
 	}
 	
 	public static function setFileHandler($file) {
-		$handler = new \Monolog\Handler\StreamHandler($file, self::$level);
+		$handler = new \Monolog\Handler\StreamHandler($file, \Monolog\Logger::toMonologLevel(\WT\Util::getConfigValue('log.level', true)));
 		$handler->setFormatter(new \Monolog\Formatter\LineFormatter(null, null, true));
 		self::getLogger()->pushHandler($handler);
 	}


### PR DESCRIPTION
The log level wasn't honored after logger object initialization.

When `debug` was set to `true` inside `config.json`
- Android client (OpenSync) couldn't auto-discovery resources (nor synchronize already configured ones)
- The webdav server was logging likes the ones below (also even if the debug was disabled):
```
[2018-07-10 16:23:06] webtop-dav-server.DEBUG: validateUserPass {"username":"lucag@nethesis.it"} []
[2018-07-10 16:23:06] webtop-dav-server.DEBUG: getPrincipalByPath {"path":"principals/lucag@nethesis.it"} []
[2018-07-10 16:23:06] webtop-dav-server.DEBUG: getPrincipalsByPrefix {"prefixPath":"principals"} []
[2018-07-10 16:23:06] webtop-dav-server.DEBUG: getCalendarsForUser {"$principalUri":"principals/lucag@nethesis.it"} []
[2018-07-10 16:23:07] webtop-dav-server.DEBUG: getCalendarsForUser {"$principalUri":"principals/lucag@nethesis.it"} []
[2018-07-10 16:23:07] webtop-dav-server.DEBUG: getPrincipalByPath {"path":"principals/lucag@nethesis.it"} []
[2018-07-10 16:23:07] webtop-dav-server.DEBUG: getPrincipalsByPrefix {"prefixPath":"principals"} []
[2018-07-10 16:23:07] webtop-dav-server.DEBUG: getGroupMembership {"principal":"principals/lucag@nethesis.it"} []
[2018-07-10 16:23:07] webtop-dav-server.DEBUG: Server launch [] []
[2018-07-10 16:23:07] webtop-dav-server.DEBUG: REPORT /webtop-dav/server.php/calendars/lucag@nethesis.it/3i2NDaWmqPwaQF/ HTTP/1.1
```
